### PR TITLE
絵文字が文字化けするバグを修正

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5113,6 +5113,11 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
       "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA=="
     },
+    "grapheme-splitter": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
+      "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ=="
+    },
     "gzip-size": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-5.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "bootstrap": "^4.1.3",
     "bootstrap-vue": "^2.0.0-rc.11",
     "cross-env": "^5.2.0",
+    "grapheme-splitter": "^1.0.4",
     "nuxt": "^2.3.4",
     "nuxt-fontawesome": "^0.4.0",
     "underscore": "^1.9.1"

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -41,6 +41,11 @@
 
 <script>
 import _ from 'underscore'
+import GraphemeSplitter from 'grapheme-splitter'
+
+const splitter = new GraphemeSplitter()
+const splitGraphemes = splitter.splitGraphemes.bind(splitter)
+
 export default {
   data() {
     return {
@@ -75,9 +80,14 @@ export default {
     convertToVerticalWritingRows(inputRows) {
       return this.joinEachRowChars(
         this.replaceNobashibo(
-          this.replaceUndefinedToSpace(_.zip(...inputRows.reverse()))
+          this.replaceUndefinedToSpace(
+            this.swapCellsAndRows(inputRows.reverse())
+          )
         )
       )
+    },
+    swapCellsAndRows(rows) {
+      return _.zip(...rows.map(splitGraphemes))
     },
     replaceUndefinedToSpace(rows) {
       return _.map(rows, row => {


### PR DESCRIPTION
入力文字列の各行を文字ごとに分割する処理を正しく直すことで、絵文字が文字化けするバグを修正しました。

このバグを修正するには、文字列を単純に1文字ごとに分けるのではなくUnicodeのgrameme clusterを考慮した分割を行う必要があります。そこで、それを行うライブラリである[grapheme-splitter](https://github.com/orling/grapheme-splitter)を新たに導入し、そのライブラリを用いて分割を行うようにしました。

この修正によってバンドルサイズは**22.5KB**増加します。

close #2 
